### PR TITLE
refactor: 날짜조회 요청값 수정, ddl 값 create로 변경

### DIFF
--- a/src/main/java/TOYUXTEAM/BOOKSTORE/domain/diary/controller/DiaryController.java
+++ b/src/main/java/TOYUXTEAM/BOOKSTORE/domain/diary/controller/DiaryController.java
@@ -1,13 +1,12 @@
 package TOYUXTEAM.BOOKSTORE.domain.diary.controller;
 
 import TOYUXTEAM.BOOKSTORE.domain.diary.dto.request.DiaryRequest;
-import TOYUXTEAM.BOOKSTORE.domain.diary.dto.response.DiaryResponse;
 import TOYUXTEAM.BOOKSTORE.domain.diary.dto.response.DiaryWithFileResponse;
 import TOYUXTEAM.BOOKSTORE.domain.diary.service.DiaryService;
-import TOYUXTEAM.BOOKSTORE.domain.diary.service.DiarySimpleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Slf4j
@@ -38,10 +38,10 @@ public class DiaryController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/{id}/list/{month}/{day}/diary") // page 9
+    @GetMapping("/{id}/list/") // page 9
     public ResponseEntity<Page<DiaryWithFileResponse>> getDiariesForDate(@PathVariable("id") Long id,
-                                            @PathVariable("month") Long month, @PathVariable("day") Long day, @RequestParam("page") int offset) {
-        return ResponseEntity.ok().body(diaryService.findByDate(id, month, day, offset));
+                                                                         @RequestParam("date") @DateTimeFormat(pattern = "yyyy-mm-dd") LocalDate date, @RequestParam("page") int offset) {
+        return ResponseEntity.ok().body(diaryService.findByDate(id, date, offset));
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/TOYUXTEAM/BOOKSTORE/domain/diary/service/DiaryService.java
+++ b/src/main/java/TOYUXTEAM/BOOKSTORE/domain/diary/service/DiaryService.java
@@ -59,12 +59,11 @@ public class DiaryService {
     }
 
     @Transactional(readOnly = true)
-    public Page<DiaryWithFileResponse> findByDate(Long userId, Long month, Long day, int offset) {
+    public Page<DiaryWithFileResponse> findByDate(Long userId, LocalDate date, int offset) {
 
         userRepository.findById(userId).orElseThrow(() -> new UserException("회원을 찾을 수없습니다."));
 
         Pageable pageable = PageRequest.of(offset, 9);
-        LocalDate date = LocalDate.of(LocalDateTime.now().getYear(), month.intValue(), day.intValue());
         DiarySearchCond diarySearchCond = new DiarySearchCond(userId, date);
 
         return diaryRepository.findByIdDiaryForDate(diarySearchCond, pageable);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,4 +18,3 @@ logging.level:
     coyote:
       http11: debug
 # org.hibernate.type: trace
-


### PR DESCRIPTION
# 상세 내용
- 기존 value값으로 입력되던 날짜 데이터를 날짜 param값으로 받도록 변경
- ddl값이 update시, 기존 값을 찾지못해 빌드를 하지 못하기 때문에 옵션 값을 create로 변경